### PR TITLE
:sparkles: Do not require occm

### DIFF
--- a/providers/openstack/ferrol/1-27/cluster-class/Chart.yaml
+++ b/providers/openstack/ferrol/1-27/cluster-class/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
     url: https://dnation.cloud
 name: openstack-ferrol-1-27-cluster-class
 type: application
-version: "v2"
+version: "v3"

--- a/providers/openstack/ferrol/1-27/cluster-class/templates/kubeadm-config-template-worker-openstack.yaml
+++ b/providers/openstack/ferrol/1-27/cluster-class/templates/kubeadm-config-template-worker-openstack.yaml
@@ -9,6 +9,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: external
+            #cloud-provider: external
             provider-id: openstack:///'{{"{{"}}instance_id{{"}}"}}'
           name: '{{"{{"}}local_hostname{{"}}"}}'

--- a/providers/openstack/ferrol/1-27/cluster-class/templates/kubeadm-control-plane-template.yaml
+++ b/providers/openstack/ferrol/1-27/cluster-class/templates/kubeadm-control-plane-template.yaml
@@ -10,19 +10,19 @@ spec:
         clusterConfiguration:
           apiServer:
             extraArgs:
-              cloud-provider: external
+              #cloud-provider: external
           controllerManager:
             extraArgs:
-              cloud-provider: external
+              #cloud-provider: external
         initConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              cloud-provider: external
+              #cloud-provider: external
               provider-id: openstack:///'{{"{{"}}instance_id{{"}}"}}'
             name: '{{"{{"}}local_hostname{{"}}"}}'
         joinConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              cloud-provider: external
+              #cloud-provider: external
               provider-id: openstack:///'{{"{{"}}instance_id{{"}}"}}'
             name: '{{"{{"}}local_hostname{{"}}"}}'

--- a/providers/openstack/ferrol/1-27/metadata.yaml
+++ b/providers/openstack/ferrol/1-27/metadata.yaml
@@ -1,6 +1,6 @@
 apiVersion: metadata.clusterstack.x-k8s.io/v1alpha1
 versions:
-  clusterStack: v2
+  clusterStack: v3
   kubernetes: v1.27.8
   components:
     clusterAddon: v2

--- a/providers/openstack/ferrol/1-27/topology-openstack.yaml
+++ b/providers/openstack/ferrol/1-27/topology-openstack.yaml
@@ -11,7 +11,7 @@ spec:
       cidrBlocks: ["192.168.0.0/16"]
     serviceDomain: "cluster.local"
   topology:
-    class: openstack-ferrol-1-27-v2
+    class: openstack-ferrol-1-27-v3
     controlPlane:
       metadata: {}
       replicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Pods cannot run on workload k8s nodes because there is taint `node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule`. See https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/ for more.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
